### PR TITLE
Fetch dotnet-install from cli's master branch

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -111,7 +111,7 @@ function Install-DotNetCli
 {
     $timer = Start-Timer
     Write-Log "Install-DotNetCli: Get dotnet-install.ps1 script..."
-    $dotnetInstallRemoteScript = "https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.ps1"
+    $dotnetInstallRemoteScript = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
     $dotnetInstallScript = Join-Path $env:TP_TOOLS_DIR "dotnet-install.ps1"
     if (-not (Test-Path $env:TP_TOOLS_DIR)) {
         New-Item $env:TP_TOOLS_DIR -Type Directory | Out-Null

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -104,7 +104,7 @@ function installdotnetcli()
     if [[ ! -e $DOTNET_INSTALL_PATH ]]; then
 
         # Install a stage 0
-        DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/rel/1.0.0/scripts/obtain/dotnet-install.sh"
+        DOTNET_INSTALL_SCRIPT_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
         curl -sSL "$DOTNET_INSTALL_SCRIPT_URL" | bash /dev/stdin  --version $DOTNET_CLI_VERSION --verbose
     fi
 


### PR DESCRIPTION
This adds support for downloading a dotnet runtime for RHEL >= 7.3.